### PR TITLE
Update installsAfter order for dotfiles-setup

### DIFF
--- a/src/dotfiles-setup/devcontainer-feature.json
+++ b/src/dotfiles-setup/devcontainer-feature.json
@@ -4,7 +4,8 @@
   "name": "Dotfiles Setup",
   "description": "Symlinks Zsh, Powerlevel10k, Git, and tmux config files from /root/code/dotfiles.",
   "installsAfter": [
-    "dotfiles-mounts"
+    "dotfiles-mounts",
+    "shared-dev-setup"
   ],
   "options": {}
 }


### PR DESCRIPTION
## Summary
- ensure dotfiles-setup runs after shared-dev-setup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b5f149e0c8327a06584f6a8b2f039