### PR TITLE
Add optional MesloLGS Nerd Font install

### DIFF
--- a/src/dotfiles-mounts/devcontainer-feature.json
+++ b/src/dotfiles-mounts/devcontainer-feature.json
@@ -1,10 +1,11 @@
 {
   "id": "dotfiles-mounts",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "name": "Dotfiles Mounts",
   "description": "Mount SSH, AWS, and dotfiles into container",
   "documentationURL": "https://github.com/blackwd-bwh/devcontainer-features/tree/main/src/dotfiles-mounts",
   "schemaVersion": 2,
+  "install": "install.sh",
   "customizations": {
     "devcontainer": {
       "features": {}

--- a/src/shared-dev-setup/devcontainer-feature.json
+++ b/src/shared-dev-setup/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "shared-dev-setup",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "name": "Shared Dev Setup",
   "description": "Installs core dev tools, dotfiles, bat, tree, and Powerlevel10k shell theme.",
   "options": {
@@ -8,6 +8,11 @@
       "type": "boolean",
       "default": false,
       "description": "Force reinstall of Oh My Zsh and Powerlevel10k even if already installed."
+    },
+    "installNerdFont": {
+      "type": "boolean",
+      "default": false,
+      "description": "Download and install MesloLGS Nerd Font."
     }
   }
 }

--- a/src/shared-dev-setup/install.sh
+++ b/src/shared-dev-setup/install.sh
@@ -28,6 +28,17 @@ fi
 # Install all packages
 apt-get install -y "${DEBIAN_PACKAGES[@]}"
 
+# MesloLGS Nerd Font (optional)
+if [[ "${_BUILD_ARG_INSTALL_NERD_FONT:-false}" == "true" ]]; then
+  echo "🔤 Installing MesloLGS Nerd Font..."
+  FONT_DIR="/usr/share/fonts/MesloLGS"
+  mkdir -p "$FONT_DIR"
+  curl -fsSL -o /tmp/Meslo.zip \
+    "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Meslo.zip"
+  unzip -o /tmp/Meslo.zip -d "$FONT_DIR"
+  fc-cache -fv "$FONT_DIR"
+fi
+
 # Zsh + Powerlevel10k handling
 if [[ "${_BUILD_ARG_FORCE_REINSTALL_ZSH:-false}" == "true" ]]; then
   echo "🔁 Forcing reinstallation of Oh My Zsh and Powerlevel10k"


### PR DESCRIPTION
## Summary
- add `installNerdFont` option to shared-dev-setup feature
- download MesloLGS Nerd Font when enabled and refresh font cache

## Testing
- `shellcheck src/shared-dev-setup/install.sh`

------
https://chatgpt.com/codex/tasks/task_e_687fe5df9654832786bcb439ec542b99