### PR TITLE
Fix start-ssh-agent setup

### DIFF
--- a/src/start-ssh-agent/install.sh
+++ b/src/start-ssh-agent/install.sh
@@ -63,4 +63,15 @@ echo "✅ SSH agent profile script created at $AGENT_ENV"
 
 # 4. SSH config alias (dotfiles host)
 if ! grep -q "Host $DOTFILES_HOST" "$CONFIG_PATH" 2>/dev/null; then
-  echo "🔧
+  echo "🔧 Adding SSH config for $DOTFILES_HOST"
+  cat <<EOC >> "$CONFIG_PATH"
+Host $DOTFILES_HOST
+  HostName $DOTFILES_HOSTNAME
+  Port $DOTFILES_PORT
+EOC
+fi
+
+if ! ssh-keygen -F "$DOTFILES_HOSTNAME" -f "$KNOWN_HOSTS" >/dev/null 2>&1; then
+  echo "🔑 Updating known_hosts for $DOTFILES_HOSTNAME"
+  ssh-keyscan -p "$DOTFILES_PORT" "$DOTFILES_HOSTNAME" >> "$KNOWN_HOSTS"
+fi


### PR DESCRIPTION
## Summary
- close echo statement and finish SSH config block
- add `$DOTFILES_HOST` alias in `~/.ssh/config`
- populate `known_hosts` for the SSH host

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68815dcfc0a88327982d68440bae145d